### PR TITLE
Separate React.MouseEvent handling from React.TouchEvent handling

### DIFF
--- a/src/components/AppFooter/AppFooter.test.tsx
+++ b/src/components/AppFooter/AppFooter.test.tsx
@@ -27,6 +27,13 @@ describe('AppFooter', () => {
         onPause: jest.fn(),
         onBloodMoon: jest.fn()
       },
+      mouseCallbacks: {
+        onSplit: jest.fn(),
+        onUndo: jest.fn(),
+        onReset: jest.fn(),
+        onPause: jest.fn(),
+        onBloodMoon: jest.fn()
+      },
       showHelp: false
     }
   });
@@ -36,6 +43,7 @@ describe('AppFooter', () => {
     ReactDOM.render(<AppFooter
       run={props.run}
       touchCallbacks={props.touchCallbacks}
+      mouseCallbacks={props.mouseCallbacks}
       showHelp={props.showHelp}
     />, div);
   });
@@ -43,6 +51,7 @@ describe('AppFooter', () => {
     const el = shallow(<AppFooter
       run={props.run}
       touchCallbacks={props.touchCallbacks}
+      mouseCallbacks={props.mouseCallbacks}
       showHelp={props.showHelp}
     />);
     expect(el.contains(<div className="footer"/>));
@@ -51,6 +60,7 @@ describe('AppFooter', () => {
     expect(mount(<AppFooter
       run={props.run}
       touchCallbacks={props.touchCallbacks}
+      mouseCallbacks={props.mouseCallbacks}
       showHelp={props.showHelp}
     />).find('.footer').length).toBe(1);
   });
@@ -58,6 +68,7 @@ describe('AppFooter', () => {
     expect(render(<AppFooter
       run={props.run}
       touchCallbacks={props.touchCallbacks}
+      mouseCallbacks={props.mouseCallbacks}
       showHelp={props.showHelp}
     />).text()).toMatch(/to start \/ split/);
   });
@@ -71,14 +82,12 @@ describe('AppFooter', () => {
       expect(shallow(<AppFooter
         run={props.run}
         touchCallbacks={props.touchCallbacks}
+        mouseCallbacks={props.mouseCallbacks}
         showHelp={props.showHelp}
       />).containsMatchingElement(<MobileControls
-        run = { props.run }
-        onSplit = { props.touchCallbacks.onSplit }
-        onUndo = { props.touchCallbacks.onUndo }
-        onReset = { props.touchCallbacks.onReset }
-        onPause = { props.touchCallbacks.onPause }
-        onBloodMoon = { props.touchCallbacks.onBloodMoon }
+        run={props.run}
+        touchCallbacks={props.touchCallbacks}
+        mouseCallbacks={props.mouseCallbacks}
       />)).toEqual(true);
     });
   });
@@ -92,6 +101,7 @@ describe('AppFooter', () => {
       expect(shallow(<AppFooter
         run={props.run}
         touchCallbacks={props.touchCallbacks}
+        mouseCallbacks={props.mouseCallbacks}
         showHelp={props.showHelp}
       />).containsMatchingElement(<DesktopHelp
         run={props.run}

--- a/src/components/AppFooter/AppFooter.tsx
+++ b/src/components/AppFooter/AppFooter.tsx
@@ -5,27 +5,31 @@ import { DesktopHelp, MobileControls } from '../Help/Help';
 export type AppFooterProps = {
   run: Run,
   touchCallbacks: {
+    onSplit: (event: React.TouchEvent) => void,
+    onUndo: (event: React.TouchEvent) => void,
+    onReset: (event: React.TouchEvent) => void,
+    onPause: (event: React.TouchEvent) => void,
+    onBloodMoon: (event: React.TouchEvent) => void,
+  },
+  mouseCallbacks: {
     onSplit: (event: React.MouseEvent) => void,
     onUndo: (event: React.MouseEvent) => void,
     onReset: (event: React.MouseEvent) => void,
     onPause: (event: React.MouseEvent) => void,
     onBloodMoon: (event: React.MouseEvent) => void,
-  };
+  },
   showHelp: boolean,
 };
 
-export function AppFooter({ run, touchCallbacks, showHelp }: AppFooterProps) {
+export function AppFooter({ run, touchCallbacks, mouseCallbacks, showHelp }: AppFooterProps) {
   const isTouch = window.matchMedia('(pointer: coarse)').matches;
   return run.seed !== '' ? (
     <div className="footer">
       {isTouch ? (
         <MobileControls
           run={run}
-          onSplit={touchCallbacks.onSplit}
-          onUndo={touchCallbacks.onUndo}
-          onReset={touchCallbacks.onReset}
-          onPause={touchCallbacks.onPause}
-          onBloodMoon={touchCallbacks.onBloodMoon}
+          touchCallbacks={touchCallbacks}
+          mouseCallbacks={mouseCallbacks}
         />
       ) : (
         <DesktopHelp run={run} showHelp={showHelp} />

--- a/src/components/Help/Help.test.tsx
+++ b/src/components/Help/Help.test.tsx
@@ -66,7 +66,7 @@ describe('Help', () => {
           run={run}
           touchCallbacks={touchCallbacks}
           mouseCallbacks={mouseCallbacks}
-          />);
+        />);
       });
       describe.skip('when tapped', () => {
         it('calls the split callback', () => {

--- a/src/components/Help/Help.test.tsx
+++ b/src/components/Help/Help.test.tsx
@@ -33,8 +33,16 @@ describe('Help', () => {
   });
 
   describe('MobileControls', () => {
-    let touchCallbacks: Record<string, (event: React.MouseEvent) => void>;
+    let mouseCallbacks: Record<string, (event: React.MouseEvent) => void>;
+    let touchCallbacks: Record<string, (event: React.TouchEvent) => void>;
     beforeEach(() => {
+      mouseCallbacks = {
+        onSplit: jest.fn(),
+        onUndo: jest.fn(),
+        onPause: jest.fn(),
+        onReset: jest.fn(),
+        onBloodMoon: jest.fn()
+      };
       touchCallbacks = {
         onSplit: jest.fn(),
         onUndo: jest.fn(),
@@ -47,11 +55,8 @@ describe('Help', () => {
       const div = document.createElement('div');
       ReactDOM.render(<MobileControls
         run={run}
-        onSplit={touchCallbacks.onSplit}
-        onUndo={touchCallbacks.onUndo}
-        onPause={touchCallbacks.onPause}
-        onReset={touchCallbacks.onReset}
-        onBloodMoon={touchCallbacks.onBloodMoon}
+        touchCallbacks={touchCallbacks}
+        mouseCallbacks={mouseCallbacks}
       />, div);
     });
     describe('touch handlers setup', () => {
@@ -59,12 +64,9 @@ describe('Help', () => {
       beforeEach(() => {
         mounted = mount(<MobileControls
           run={run}
-          onSplit={touchCallbacks.onSplit}
-          onUndo={touchCallbacks.onUndo}
-          onPause={touchCallbacks.onPause}
-          onReset={touchCallbacks.onReset}
-          onBloodMoon={touchCallbacks.onBloodMoon}
-        />);
+          touchCallbacks={touchCallbacks}
+          mouseCallbacks={mouseCallbacks}
+          />);
       });
       describe.skip('when tapped', () => {
         it('calls the split callback', () => {
@@ -98,24 +100,48 @@ describe('Help', () => {
       describe('when clicked', () => {
         it('calls the split callback', () => {
           mounted.find('button.split').simulate('click');
-          expect(touchCallbacks.onSplit).toHaveBeenCalledTimes(1);
+          expect(mouseCallbacks.onSplit).toHaveBeenCalledTimes(1);
         });
         it.skip('calls the skip callback - there is no skip callback?', () => { });
         it('calls the undo callback', () => {
           mounted.find('button.undo').simulate('click');
-          expect(touchCallbacks.onUndo).toHaveBeenCalledTimes(1);
+          expect(mouseCallbacks.onUndo).toHaveBeenCalledTimes(1);
         });
         it('calls the pause callback', () => {
           mounted.find('button.pause').simulate('click');
-          expect(touchCallbacks.onPause).toHaveBeenCalledTimes(1);
+          expect(mouseCallbacks.onPause).toHaveBeenCalledTimes(1);
         });
         it.skip('resumes the timer - no way to test this here', () => { });
         it('calls the reset callback', () => {
           mounted.find('button.pause').simulate('click');
-          expect(touchCallbacks.onPause).toHaveBeenCalledTimes(1);
+          expect(mouseCallbacks.onPause).toHaveBeenCalledTimes(1);
         });
         it('calls the bloodmoon callback', () => {
           mounted.find('button.bloodmoon').simulate('click');
+          expect(mouseCallbacks.onBloodMoon).toHaveBeenCalledTimes(1);
+        });
+      });
+      describe('when tapped', () => {
+        it('calls the split callback', () => {
+          mounted.find('button.split').simulate('touchEnd');
+          expect(touchCallbacks.onSplit).toHaveBeenCalledTimes(1);
+        });
+        it.skip('calls the skip callback - there is no skip callback?', () => { });
+        it('calls the undo callback', () => {
+          mounted.find('button.undo').simulate('touchEnd');
+          expect(touchCallbacks.onUndo).toHaveBeenCalledTimes(1);
+        });
+        it('calls the pause callback', () => {
+          mounted.find('button.pause').simulate('touchEnd');
+          expect(touchCallbacks.onPause).toHaveBeenCalledTimes(1);
+        });
+        it.skip('resumes the timer - no way to test this here', () => { });
+        it('calls the reset callback', () => {
+          mounted.find('button.pause').simulate('touchEnd');
+          expect(touchCallbacks.onPause).toHaveBeenCalledTimes(1);
+        });
+        it('calls the bloodmoon callback', () => {
+          mounted.find('button.bloodmoon').simulate('touchEnd');
           expect(touchCallbacks.onBloodMoon).toHaveBeenCalledTimes(1);
         });
       });

--- a/src/components/Help/Help.tsx
+++ b/src/components/Help/Help.tsx
@@ -4,29 +4,41 @@ import { Run } from '../../lib/run';
 
 type MobileProps = {
   run: Run;
-  onSplit: (event: React.MouseEvent | React.TouchEvent) => void;
-	onUndo: (event: React.MouseEvent | React.TouchEvent) => void;
-	onReset: (event: React.MouseEvent | React.TouchEvent) => void;
-	onPause: (event: React.MouseEvent | React.TouchEvent) => void;
-	onBloodMoon: (event: React.MouseEvent | React.TouchEvent) => void;
+  touchCallbacks: {
+    onSplit: (event: React.TouchEvent) => void;
+    onUndo: (event: React.TouchEvent) => void;
+    onReset: (event: React.TouchEvent) => void;
+    onPause: (event: React.TouchEvent) => void;
+    onBloodMoon: (event: React.TouchEvent) => void;
+  },
+  mouseCallbacks: {
+    onSplit: (event: React.MouseEvent) => void;
+    onUndo: (event: React.MouseEvent) => void;
+    onReset: (event: React.MouseEvent) => void;
+    onPause: (event: React.MouseEvent) => void;
+    onBloodMoon: (event: React.MouseEvent) => void;
+  }
 };
 
 export const MobileControls = (props: MobileProps) => {
+  const mouse = props.mouseCallbacks;
+  const touch = props.touchCallbacks;
+
   return (
     <div className="touchpanel">
-      <button className="split" onClick={props.onSplit} onTouchEnd={props.onSplit}>
+      <button className="split" onClick={mouse.onSplit} onTouchEnd={touch.onSplit}>
 				Split
       </button>
-      <button className="undo" onClick={props.onUndo} onTouchEnd={props.onSplit}>
+      <button className="undo" onClick={mouse.onUndo} onTouchEnd={touch.onUndo}>
 				Undo
       </button>
-      <button className="pause" onClick={props.onPause} onTouchEnd={props.onSplit}>
+      <button className="pause" onClick={mouse.onPause} onTouchEnd={touch.onPause}>
 				Pause
       </button>
-      <button className="reset" onClick={props.onReset} onTouchEnd={props.onSplit}>
+      <button className="reset" onClick={mouse.onReset} onTouchEnd={touch.onReset}>
 				Reset
       </button>
-      <button className="bloodmoon" onClick={props.onBloodMoon} onTouchEnd={props.onSplit}>
+      <button className="bloodmoon" onClick={mouse.onBloodMoon} onTouchEnd={touch.onBloodMoon}>
 				Blood Moon
       </button>
     </div>

--- a/src/components/Help/Help.tsx
+++ b/src/components/Help/Help.tsx
@@ -27,19 +27,19 @@ export const MobileControls = (props: MobileProps) => {
   return (
     <div className="touchpanel">
       <button className="split" onClick={mouse.onSplit} onTouchEnd={touch.onSplit}>
-				Split
+        Split
       </button>
       <button className="undo" onClick={mouse.onUndo} onTouchEnd={touch.onUndo}>
-				Undo
+        Undo
       </button>
       <button className="pause" onClick={mouse.onPause} onTouchEnd={touch.onPause}>
-				Pause
+        Pause
       </button>
       <button className="reset" onClick={mouse.onReset} onTouchEnd={touch.onReset}>
-				Reset
+        Reset
       </button>
       <button className="bloodmoon" onClick={mouse.onBloodMoon} onTouchEnd={touch.onBloodMoon}>
-				Blood Moon
+        Blood Moon
       </button>
     </div>
   );
@@ -58,7 +58,7 @@ export const DesktopHelp = (props: DesktopProps) => {
         <>
           <div className="helphint">
             <span className="key">Space</span> to start / split
-						&nbsp;
+            &nbsp;
             <span className="key">H</span> to show / hide help
           </div>
         </>

--- a/src/components/RunManager/RunManager.tsx
+++ b/src/components/RunManager/RunManager.tsx
@@ -153,12 +153,20 @@ export const RunManager = (props: RunManagerProps) => {
     return classes.join(' ');
   };
 
+  // This insanity is because the conversion from TS to JS can't handle the mixed types.
+  const mouseCallbacks = {
+    onSplit: (_e: React.MouseEvent) => { addSplit() },
+    onUndo: (_e: React.MouseEvent) => { undoSplit() },
+    onReset: (_e: React.MouseEvent) => { resetSplits() },
+    onPause: (_e: React.MouseEvent) => { pause() },
+    onBloodMoon: (_e: React.MouseEvent) => { toggleBloodMoon() }
+  };
   const touchCallbacks = {
-    onSplit: addSplit,
-    onUndo: undoSplit,
-    onReset: resetSplits,
-    onPause: pause,
-    onBloodMoon: toggleBloodMoon
+    onSplit: (_e: React.TouchEvent) => { addSplit() },
+    onUndo: (_e: React.TouchEvent) => { undoSplit() },
+    onReset: (_e: React.TouchEvent) => { resetSplits() },
+    onPause: (_e: React.TouchEvent) => { pause() },
+    onBloodMoon: (_e: React.TouchEvent) => { toggleBloodMoon() }
   };
 
   const onPickedSeed = (seed: string) => {
@@ -184,6 +192,7 @@ export const RunManager = (props: RunManagerProps) => {
         <AppFooter
           run={run}
           touchCallbacks={touchCallbacks}
+          mouseCallbacks={mouseCallbacks}
           showHelp={showHelp}
         />
       </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3551,7 +3551,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
+debug@^3.0.0, debug@^3.1.1, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -3593,11 +3593,6 @@ deep-equal@^1.0.1:
     object-is "^1.0.1"
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
-
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -3681,11 +3676,6 @@ destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-newline@^2.1.0:
   version "2.1.0"
@@ -4891,13 +4881,6 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-minipass@^1.2.5:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
-  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
-  dependencies:
-    minipass "^2.6.0"
-
 fs-minipass@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
@@ -5452,7 +5435,7 @@ humanize-url@^1.0.0:
     normalize-url "^1.0.0"
     strip-url-auth "^1.0.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
+iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -5482,13 +5465,6 @@ iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
-
-ignore-walk@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
-  integrity sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
-  dependencies:
-    minimatch "^3.0.4"
 
 ignore@^3.3.5:
   version "3.3.10"
@@ -5598,7 +5574,7 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@^1.3.5, ini@~1.3.0:
+ini@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -7320,27 +7296,12 @@ minipass-pipeline@^1.2.2:
   dependencies:
     minipass "^3.0.0"
 
-minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
-  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
-  dependencies:
-    safe-buffer "^5.1.2"
-    yallist "^3.0.0"
-
 minipass@^3.0.0, minipass@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.1.tgz#7607ce778472a185ad6d89082aa2070f79cedcd5"
   integrity sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==
   dependencies:
     yallist "^4.0.0"
-
-minizlib@^1.2.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
-  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
-  dependencies:
-    minipass "^2.9.0"
 
 mississippi@^3.0.0:
   version "3.0.0"
@@ -7474,15 +7435,6 @@ nearley@^2.7.10:
     randexp "0.4.6"
     semver "^5.4.1"
 
-needle@^2.2.1:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.3.3.tgz#a041ad1d04a871b0ebb666f40baaf1fb47867117"
-  integrity sha512-EkY0GeSq87rWp1hoq/sH/wnTWgFVhYlnIkbJ0YJFfRgEFlz2RraCjBpFQ+vrEgEdp0ThfyHADmkChEhcb7PKyw==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -7584,22 +7536,6 @@ node-notifier@^5.4.2:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-releases@^1.1.52:
   version "1.1.53"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.53.tgz#2d821bfa499ed7c5dffc5e2f28c88e78a08ee3f4"
@@ -7634,14 +7570,6 @@ node-sass@^4.13.1:
   integrity sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
   dependencies:
     abbrev "1"
-
-nopt@^4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.3.tgz#a375cad9d02fd921278d954c2254d5aa57e15e48"
-  integrity sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==
-  dependencies:
-    abbrev "1"
-    osenv "^0.1.4"
 
 normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
   version "2.5.0"
@@ -7685,27 +7613,6 @@ normalize-url@^3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
 
-npm-bundled@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.1.tgz#1edd570865a94cdb1bc8220775e29466c9fb234b"
-  integrity sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
-  dependencies:
-    npm-normalize-package-bin "^1.0.1"
-
-npm-normalize-package-bin@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
-  integrity sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
-
-npm-packlist@^1.1.6:
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
-  integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
-  dependencies:
-    ignore-walk "^3.0.1"
-    npm-bundled "^1.0.1"
-    npm-normalize-package-bin "^1.0.1"
-
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -7713,7 +7620,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0, npmlog@^4.0.2:
+"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -7955,7 +7862,7 @@ os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
-osenv@0, osenv@^0.1.4:
+osenv@0:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
   integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
@@ -9281,16 +9188,6 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-rc@^1.2.7:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
 react-app-polyfill@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/react-app-polyfill/-/react-app-polyfill-1.0.6.tgz#890f8d7f2842ce6073f030b117de9130a5f385f0"
@@ -9849,7 +9746,7 @@ rgba-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
 
-rimraf@2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.3, rimraf@^2.7.1:
+rimraf@2, rimraf@^2.5.4, rimraf@^2.6.3, rimraf@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -10030,7 +9927,7 @@ selfsigned@^1.10.7:
   dependencies:
     node-forge "0.9.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -10691,11 +10588,6 @@ strip-json-comments@^3.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.0.1.tgz#85713975a91fb87bf1b305cca77395e40d2a64a7"
   integrity sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==
 
-strip-json-comments@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
-
 strip-outer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/strip-outer/-/strip-outer-1.0.1.tgz#b2fd2abf6604b9d1e6013057195df836b8a9d631"
@@ -10803,19 +10695,6 @@ tar@^2.0.0:
     block-stream "*"
     fstream "^1.0.12"
     inherits "2"
-
-tar@^4.4.2:
-  version "4.4.13"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
-  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
-  dependencies:
-    chownr "^1.1.1"
-    fs-minipass "^1.2.5"
-    minipass "^2.8.6"
-    minizlib "^1.2.1"
-    mkdirp "^0.5.0"
-    safe-buffer "^5.1.2"
-    yallist "^3.0.3"
 
 terser-webpack-plugin@2.3.5:
   version "2.3.5"
@@ -11771,7 +11650,7 @@ yallist@^2.1.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
-yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
+yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==


### PR DESCRIPTION
TypeScript views `React.MouseEvent` and `React.TouchEvent` as incompatible types, so doing a union type here doesn't work so well. To fix this, I restructured the `MobileControls` props to take objects (actually, a `Record` type, but same thing) of functions, then passed two: one for mouse events and the other for touch events.