### PR TITLE
Refactor SeedInfo logic to simplify rendering and add tests

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -1,24 +1,11 @@
 import React from 'react';
 import '../../assets/bloodmoon.svg';
-// import { getRandomizedShrines } from "../../lib/rando";
-import { Run, RunState } from '../../lib/run';
 import '../../styles/style.scss';
+import { Run, getDefaultRun } from '../../lib/run';
 import { RunManager } from '../RunManager/RunManager';
 
 function App() {
-  // const testSeed = "420SPECSNLUL69";
-  // getRandomizedShrines(testSeed)
-  const run: Run = {
-    state: RunState.None,
-    runner: 'Probably Specs',
-    rundate: -1,
-    pausedTime: -1,
-    seed: '',
-    waypointIds: [],
-    splits: new Map([]),
-    pbSplits: new Map([]),
-    wrSplits: new Map([])
-  };
+  const run: Run = getDefaultRun();
 
   return (
     <>

--- a/src/components/RunManager/RunManager.tsx
+++ b/src/components/RunManager/RunManager.tsx
@@ -173,6 +173,10 @@ export const RunManager = (props: RunManagerProps) => {
     setRunState(RunState.Init);
   };
 
+  const onToggleShowSeed = () => {
+    setRun(prev => ({ ...prev, showSeed: !prev.showSeed }));
+  };
+
   const mainsection = () =>
     run.state === RunState.None ? (
       <SeedPicker onPickedSeed={onPickedSeed} />
@@ -185,7 +189,7 @@ export const RunManager = (props: RunManagerProps) => {
       <KeyboardEventHandler handleKeys={['all']} onKeyEvent={handleKey} />
       <div className="main">
         <AppHeader hasSeed={!!run.seed} setRun={setRun} />
-        <SeedInfo run={run} />
+        <SeedInfo seed={run.seed} showSeed={run.showSeed} toggleShowSeed={onToggleShowSeed} />
         {mainsection()}
         <AppFooter
           run={run}

--- a/src/components/SeedInfo/SeedInfo.test.tsx
+++ b/src/components/SeedInfo/SeedInfo.test.tsx
@@ -2,101 +2,164 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { shallow, mount, render } from 'enzyme';
 import { SeedInfo, SeedInfoProps } from './SeedInfo';
-import { getDefaultRun } from '../../lib/run';
 
 describe('SeedInfo', () => {
   let props: SeedInfoProps;
+  let showSeed: boolean;
   beforeEach(() => {
-    props = { run: getDefaultRun() }
+    const onToggleShowSeed = jest.fn().mockImplementation(() => { showSeed = !showSeed; });
+    showSeed = false;
+    props = { seed: '', showSeed: showSeed, toggleShowSeed: onToggleShowSeed }
   });
   describe('when no seed is set', () => {
     it('renders without crashing', () => {
       const div = document.createElement('div');
-      ReactDOM.render(<SeedInfo run={props.run} />, div);
+      ReactDOM.render(
+        <SeedInfo
+          seed={props.seed}
+          showSeed={props.showSeed}
+          toggleShowSeed={props.toggleShowSeed}
+        />, div
+      );
     });
     it('renders the empty seedinfo div', () => {
-      const el = shallow(<SeedInfo run={props.run} />);
+      const el = shallow(
+        <SeedInfo
+          seed={props.seed}
+          showSeed={props.showSeed}
+          toggleShowSeed={props.toggleShowSeed}
+        />
+      );
       expect(el.contains(<div className="seedinfo" />));
     });
     it('mounts in a full DOM', () => {
-      expect(mount(<SeedInfo run={props.run} />).find('.seedinfo'))
+      expect(mount(
+        <SeedInfo
+          seed={props.seed}
+          showSeed={props.showSeed}
+          toggleShowSeed={props.toggleShowSeed}
+        />
+      ).find('.seedinfo'))
         .toHaveLength(1);
     });
   });
   describe('when a seed is set', () => {
     beforeEach(() => {
-      props.run.seed = 'abc123';
+      props.seed = 'abc123';
     });
-    describe('upon load', () => {
+    describe('when showSeed is false', () => {
+      beforeEach(() => {
+        props.showSeed = false;
+      });
       it('renders the seed div', () => {
-        const wrapper = mount(<SeedInfo run={props.run} />);
+        const wrapper = mount(
+          <SeedInfo
+            seed={props.seed}
+            showSeed={props.showSeed}
+            toggleShowSeed={props.toggleShowSeed}
+          />
+        );
         expect(wrapper.find('div.seed').exists()).toBe(true);
       });
       it('does not render the seednumber div', () => {
-        const wrapper = mount(<SeedInfo run={props.run} />);
+        const wrapper = mount(
+          <SeedInfo
+            seed={props.seed}
+            showSeed={props.showSeed}
+            toggleShowSeed={props.toggleShowSeed}
+          />
+        );
         expect(wrapper.find('div.seednumber').exists()).not.toBe(true);
       });
       it('should not render seed text', () => {
-        expect(render(<SeedInfo run={props.run} />).text())
+        expect(render(
+          <SeedInfo
+            seed={props.seed}
+            showSeed={props.showSeed}
+            toggleShowSeed={props.toggleShowSeed}
+          />
+        ).text())
           .not.toMatch(/abc123/);
+      });
+      it('displays a Show Seed toggle link', () => {
+        expect(render(
+          <SeedInfo
+            seed={props.seed}
+            showSeed={props.showSeed}
+            toggleShowSeed={props.toggleShowSeed}
+          />
+        ).find('span.toggle').text()).toMatch(/Show seed/);
+      });
+    });
+    describe('when showSeed is true', () => {
+      beforeEach(() => {
+        props.showSeed = true;
+      });
+      it('renders the seed div', () => {
+        const wrapper = mount(
+          <SeedInfo
+            seed={props.seed}
+            showSeed={props.showSeed}
+            toggleShowSeed={props.toggleShowSeed}
+          />
+        );
+        expect(wrapper.find('div.seed').exists()).toBe(true);
+      });
+      it('renders the seednumber div', () => {
+        const wrapper = mount(
+          <SeedInfo
+            seed={props.seed}
+            showSeed={props.showSeed}
+            toggleShowSeed={props.toggleShowSeed}
+          />
+        );
+        expect(wrapper
+          .containsMatchingElement(<span className="seednumber">Seed: abc123 </span>))
+          .toEqual(true);
+      });
+      it('renders the seed text', () => {
+        expect(render(
+          <SeedInfo
+            seed={props.seed}
+            showSeed={props.showSeed}
+            toggleShowSeed={props.toggleShowSeed}
+          />
+        ).text()).toMatch(/abc123/);
+      });
+      it('displays a Hide toggle link', () => {
+        expect(render(
+          <SeedInfo
+            seed={props.seed}
+            showSeed={props.showSeed}
+            toggleShowSeed={props.toggleShowSeed}
+          />
+        ).find('span.toggle').text()).toMatch(/Hide/);
       });
     });
     describe('when the Show Seed link is clicked', () => {
-      it('renders the seednumber div', () => {
-        const wrapper = mount(<SeedInfo run={props.run} />);
-        expect(wrapper.find('div.seed').exists()).toBe(true);
-        expect(wrapper.find('div.seednumber').exists()).toBe(false);
+      it('calls the toggleShowSeed function', () => {
+        const wrapper = mount(
+          <SeedInfo
+            seed={props.seed}
+            showSeed={props.showSeed}
+            toggleShowSeed={props.toggleShowSeed}
+          />
+        );
         wrapper.find('span.toggle').simulate('click');
-        expect(wrapper
-          .containsMatchingElement(<span className="seednumber">Seed: abc123 </span>))
-          .toEqual(true);
-      });
-      it('should render seed text', () => {
-        const wrapper = mount(<SeedInfo run={props.run} />);
-        expect(wrapper.text()).not.toMatch(/abc123/);
-        wrapper.find('span.toggle').simulate('click');
-        expect(wrapper.text()).toMatch(/abc123/);
-      });
-      it('shows a Hide link', () => {
-        const wrapper = mount(<SeedInfo run={props.run} />);
-        expect(wrapper.text()).toMatch(/Show seed/);
-        wrapper.find('span.toggle').simulate('click');
-        expect(wrapper.text()).toMatch(/Hide/);
+        expect(props.toggleShowSeed).toHaveBeenCalledTimes(1);
       });
     });
     describe('when the Hide link is clicked', () => {
-      it('hides the seednumber div', () => {
-        // setup: seednumber should be showing
-        const wrapper = mount(<SeedInfo run={props.run} />);
+      it('calls the toggleShowSeed function', () => {
+        const wrapper = mount(
+          <SeedInfo
+            seed={props.seed}
+            showSeed={props.showSeed}
+            toggleShowSeed={props.toggleShowSeed}
+          />
+        );
         wrapper.find('span.toggle').simulate('click');
-        expect(wrapper.find('div.seed').exists()).toBe(true);
-        expect(wrapper
-          .containsMatchingElement(<span className="seednumber">Seed: abc123 </span>))
-          .toEqual(true);
-        expect(wrapper.text()).toMatch(/Hide/);
-        // test: click the toggle, and it should be gone
-        wrapper.find('span.toggle').simulate('click');
-        expect(wrapper.find('div.seednumber').exists()).toBe(false);
-      });
-      it('should render the expected text', () => {
-        // setup: seed text should be visible
-        const wrapper = mount(<SeedInfo run={props.run} />);
-        expect(wrapper.text()).not.toMatch(/abc123/);
-        wrapper.find('span.toggle').simulate('click');
-        expect(wrapper.text()).toMatch(/abc123/);
-        // test: click the toggle, and it should be gone
-        wrapper.find('span.toggle').simulate('click');
-        expect(wrapper.text()).not.toMatch(/abc123/);
-      });
-      it('shows a Show Seed link', () => {
-        // setup: toggle link should say 'Hide'
-        const wrapper = mount(<SeedInfo run={props.run} />);
-        expect(wrapper.text()).toMatch(/Show seed/);
-        wrapper.find('span.toggle').simulate('click');
-        expect(wrapper.text()).toMatch(/Hide/);
-        // test: click toggle and toggle link should change
-        wrapper.find('span.toggle').simulate('click');
-        expect(wrapper.text()).toMatch(/Show seed/);
+        expect(props.toggleShowSeed).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/src/components/SeedInfo/SeedInfo.test.tsx
+++ b/src/components/SeedInfo/SeedInfo.test.tsx
@@ -9,45 +9,95 @@ describe('SeedInfo', () => {
   beforeEach(() => {
     props = { run: getDefaultRun() }
   });
-
-  it('renders without crashing', () => {
-    const div = document.createElement('div');
-    ReactDOM.render(<SeedInfo run={props.run} />, div);
-  });
-  it('renders the footer contents', () => {
-    const el = shallow(<SeedInfo run={props.run} />);
-    expect(el.contains(<div className="seedinfo"/>));
-  });
-  it('mounts in a full DOM', () => {
-    expect(mount(<SeedInfo run={props.run} />).find('.seedinfo'))
-      .toHaveLength(1);
-  });
-  describe('when there is no seed', () => {
-    it('does not render the seed div', () => {
-      expect(shallow(<SeedInfo run={props.run} />)
-        .containsMatchingElement(<div className="seed" />))
-        .toEqual(false);
-      expect(shallow(<SeedInfo run={props.run} />)
-        .containsMatchingElement(<div className="seed">Seed: </div>))
-        .toEqual(false);
+  describe('when no seed is set', () => {
+    it('renders without crashing', () => {
+      const div = document.createElement('div');
+      ReactDOM.render(<SeedInfo run={props.run} />, div);
     });
-    it('should not render seed text', () => {
-      expect(render(<SeedInfo run={props.run} />).text())
-        .not.toMatch(/Seed/);
+    it('renders the empty seedinfo div', () => {
+      const el = shallow(<SeedInfo run={props.run} />);
+      expect(el.contains(<div className="seedinfo" />));
+    });
+    it('mounts in a full DOM', () => {
+      expect(mount(<SeedInfo run={props.run} />).find('.seedinfo'))
+        .toHaveLength(1);
     });
   });
-  describe('when there is a seed set', () => {
+  describe('when a seed is set', () => {
     beforeEach(() => {
       props.run.seed = 'abc123';
     });
-    it('renders the seed div', () => {
-      expect(shallow(<SeedInfo run={props.run} />)
-        .containsMatchingElement(<div className="seed">Seed: abc123</div>))
-        .toEqual(true);
+    describe('upon load', () => {
+      it('renders the seed div', () => {
+        const wrapper = mount(<SeedInfo run={props.run} />);
+        expect(wrapper.find('div.seed').exists()).toBe(true);
+      });
+      it('does not render the seednumber div', () => {
+        const wrapper = mount(<SeedInfo run={props.run} />);
+        expect(wrapper.find('div.seednumber').exists()).not.toBe(true);
+      });
+      it('should not render seed text', () => {
+        expect(render(<SeedInfo run={props.run} />).text())
+          .not.toMatch(/abc123/);
+      });
     });
-    it('should render the expected text', () => {
-      expect(render(<SeedInfo run={props.run} />).text())
-        .toMatch(/Seed: abc123/);
+    describe('when the Show Seed link is clicked', () => {
+      it('renders the seednumber div', () => {
+        const wrapper = mount(<SeedInfo run={props.run} />);
+        expect(wrapper.find('div.seed').exists()).toBe(true);
+        expect(wrapper.find('div.seednumber').exists()).toBe(false);
+        wrapper.find('span.toggle').simulate('click');
+        expect(wrapper
+          .containsMatchingElement(<span className="seednumber">Seed: abc123 </span>))
+          .toEqual(true);
+      });
+      it('should render seed text', () => {
+        const wrapper = mount(<SeedInfo run={props.run} />);
+        expect(wrapper.text()).not.toMatch(/abc123/);
+        wrapper.find('span.toggle').simulate('click');
+        expect(wrapper.text()).toMatch(/abc123/);
+      });
+      it('shows a Hide link', () => {
+        const wrapper = mount(<SeedInfo run={props.run} />);
+        expect(wrapper.text()).toMatch(/Show seed/);
+        wrapper.find('span.toggle').simulate('click');
+        expect(wrapper.text()).toMatch(/Hide/);
+      });
+    });
+    describe('when the Hide link is clicked', () => {
+      it('hides the seednumber div', () => {
+        // setup: seednumber should be showing
+        const wrapper = mount(<SeedInfo run={props.run} />);
+        wrapper.find('span.toggle').simulate('click');
+        expect(wrapper.find('div.seed').exists()).toBe(true);
+        expect(wrapper
+          .containsMatchingElement(<span className="seednumber">Seed: abc123 </span>))
+          .toEqual(true);
+        expect(wrapper.text()).toMatch(/Hide/);
+        // test: click the toggle, and it should be gone
+        wrapper.find('span.toggle').simulate('click');
+        expect(wrapper.find('div.seednumber').exists()).toBe(false);
+      });
+      it('should render the expected text', () => {
+        // setup: seed text should be visible
+        const wrapper = mount(<SeedInfo run={props.run} />);
+        expect(wrapper.text()).not.toMatch(/abc123/);
+        wrapper.find('span.toggle').simulate('click');
+        expect(wrapper.text()).toMatch(/abc123/);
+        // test: click the toggle, and it should be gone
+        wrapper.find('span.toggle').simulate('click');
+        expect(wrapper.text()).not.toMatch(/abc123/);
+      });
+      it('shows a Show Seed link', () => {
+        // setup: toggle link should say 'Hide'
+        const wrapper = mount(<SeedInfo run={props.run} />);
+        expect(wrapper.text()).toMatch(/Show seed/);
+        wrapper.find('span.toggle').simulate('click');
+        expect(wrapper.text()).toMatch(/Hide/);
+        // test: click toggle and toggle link should change
+        wrapper.find('span.toggle').simulate('click');
+        expect(wrapper.text()).toMatch(/Show seed/);
+      });
     });
   });
 });

--- a/src/components/SeedInfo/SeedInfo.tsx
+++ b/src/components/SeedInfo/SeedInfo.tsx
@@ -1,19 +1,16 @@
-import React, { useState } from 'react';
-import { Run } from '../../lib/run';
+import React from 'react';
 import './SeedInfo.scss';
 
 export type SeedInfoProps = {
-  run: Run
+  seed: string,
+  showSeed: boolean,
+  toggleShowSeed: () => void
 }
 
-export function SeedInfo({ run }: SeedInfoProps) {
-  const [showSeed, setShowSeed] = useState(false);
-
-  const toggleShowSeed = () => (setShowSeed(!showSeed));
-
+export function SeedInfo({ seed, showSeed, toggleShowSeed }: SeedInfoProps) {
   const seedNumber = () => {
     return showSeed ? (
-      <span className='seednumber'>Seed: {run.seed} </span>
+      <span className='seednumber'>Seed: {seed} </span>
     ) : (
       <></>
     );
@@ -24,10 +21,10 @@ export function SeedInfo({ run }: SeedInfoProps) {
   }
 
   const seedViewer = () => {
-    return run.seed ? (
+    return seed ? (
       <div className='seed'>
         {seedNumber()}
-        <span className='toggle' onClick={() => toggleShowSeed()}>{toggleText()}</span>
+        <span className='toggle' onClick={toggleShowSeed}>{toggleText()}</span>
       </div>
     ) : (
       <></>

--- a/src/components/SeedInfo/SeedInfo.tsx
+++ b/src/components/SeedInfo/SeedInfo.tsx
@@ -9,28 +9,34 @@ export type SeedInfoProps = {
 export function SeedInfo({ run }: SeedInfoProps) {
   const [showSeed, setShowSeed] = useState(false);
 
-  const toggleSeed = (isVisible: boolean) => (setShowSeed(isVisible));
+  const toggleShowSeed = () => (setShowSeed(!showSeed));
 
-  const seedViewer = () => (
-    (<div className='seed'>
+  const seedNumber = () => {
+    return showSeed ? (
       <span className='seednumber'>Seed: {run.seed} </span>
-      <span className='toggle' onClick={() => toggleSeed(false)}> Hide </span>
-    </div>)
-  )
+    ) : (
+      <></>
+    );
+  }
+
+  const toggleText = () => {
+    return showSeed ? ' Hide ' : ' Show seed ';
+  }
+
+  const seedViewer = () => {
+    return run.seed ? (
+      <div className='seed'>
+        {seedNumber()}
+        <span className='toggle' onClick={() => toggleShowSeed()}>{toggleText()}</span>
+      </div>
+    ) : (
+      <></>
+    )
+  }
 
   return (
     <div className='seedinfo'>
-      {run.seed ?
-
-        showSeed ?
-          seedViewer() :
-          (
-            <div className='seed'>
-              <div className='toggle' onClick={() => toggleSeed(true)}> Show seed </div>
-            </div>
-          ) :
-        (<></>)
-      }
+      {seedViewer()}
     </div>
   );
 }

--- a/src/lib/run.ts
+++ b/src/lib/run.ts
@@ -1,21 +1,22 @@
 export enum RunState {
-	None,
-	Init,
-	Running,
-	Paused,
-	Ended
+  None,
+  Init,
+  Running,
+  Paused,
+  Ended,
 }
 
 export type Run = {
-	state: RunState;
-	runner: string;
-	rundate: number;
-	pausedTime: number;
-	seed: string;
-	waypointIds: number[];
-	splits: Map<number, number>;
-	wrSplits: Map<number, number>;
-	pbSplits: Map<number, number>;
+  state: RunState;
+  runner: string;
+  rundate: number;
+  pausedTime: number;
+  seed: string;
+  showSeed: boolean;
+  waypointIds: number[];
+  splits: Map<number, number>;
+  wrSplits: Map<number, number>;
+  pbSplits: Map<number, number>;
 };
 
 export const getDefaultRun = () => ({
@@ -24,6 +25,7 @@ export const getDefaultRun = () => ({
   rundate: -1,
   pausedTime: -1,
   seed: '',
+  showSeed: false,
   waypointIds: [],
   splits: new Map<number, number>([]),
   wrSplits: new Map<number, number>([]),


### PR DESCRIPTION
@teetow I did some work here to add tests, and in the course of doing that found a few ways to simplify the rendering logic. Take a look and let me know what you think -- merge if you're comfortable with it.

This patches #44.